### PR TITLE
Collect `clusterlogging` and `clusterlogforwarder`

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -67,6 +67,9 @@ resources+=(rolebindings)
 resources+=(configmaps)
 resources+=(serviceaccounts)
 resources+=(events)
+# the following ones are only in the openshift-logging namespace, but it should not impact a lot to run the inspect in the other namespaces
+resources+=(clusterlogging)
+resources+=(clusterlogforwarder)
 
 log "BEGIN inspecting namespaces ..." >> "${LOGFILE_PATH}"
 
@@ -123,7 +126,7 @@ if [ "$found_es" != "" ] || [ "$found_lokistack" != "" ] ; then
   if [ "$found" != "" ] ; then
     KUBECACHEDIR=${BASE_COLLECTION_PATH}/cache-dir ${SCRIPT_DIR}/gather_visualization_resources "$BASE_COLLECTION_PATH" >> "${LOGFILE_PATH}" 2>&1
   fi
-  log "BEGIN gathering CLO resources ..." >> "${LOGFILE_PATH}"
+  log "END gathering logstorage resources ..." >> "${LOGFILE_PATH}"
 else
   log "Skipping logstorage inspection.  No Elasticsearch deployment found" >> "${LOGFILE_PATH}" 2>&1
 fi

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -49,6 +49,8 @@ cluster_resources+=(clusterrolebindings)
 cluster_resources+=(persistentvolumes)
 cluster_resources+=(clusterversion)
 cluster_resources+=(machineconfigpool)
+cluster_resources+=(clusterlogging)
+cluster_resources+=(clusterlogforwarder)
 
 log "-BEGIN inspecting CRs..." >> "${LOGFILE_PATH}"
 for cr in "${cluster_resources[@]}" ; do


### PR DESCRIPTION
### Description
Get the  `clusterlogging` and `clusterlogforwarder` with the `oc adm inspect` to avoid the issue reported in LOG-4792.

With this change, the following code could be probably removed:
https://github.com/oarribas/cluster-logging-operator/blob/c07cff8d2ccbb714042a66e88cb524fda0631942/must-gather/collection-scripts/gather_cluster_logging_operator_resources#L45-L48
Maybe the files should be copied/linked in that location from the ones collected by the `oc adm inspect`?

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4792

