### PR TITLE
Collecting `clusterlogging` and `clusterlogforwarder` with inspect

### DIFF
--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -36,12 +36,11 @@ Example must-gather for cluster-logging output:
 ```
 ├── cluster-logging
 │  ├── clo
-│  │  ├── cluster-logging-operator-74dd5994f-6ttgt
-│  │  ├── clusterlogforwarder_cr
-│  │  ├── cr
-│  │  ├── csv
-│  │  ├── deployment
-│  │  └── logforwarding_cr
+│  │  ├── [nampespace_name]       ## including openshift-logging
+│  │  │  ├── cluster-logging-operator-74dd5994f-6ttgt
+│  │  │  ├── cr
+│  │  │  ├── csv
+│  │  │  └── deployment
 │  ├── collector
 │  │  ├── fluentd-2tr64
 │  ├── eo
@@ -85,7 +84,7 @@ Example must-gather for cluster-logging output:
 ├── event-filter.html
 ├── gather-debug.log
 └── namespaces
-   ├── openshift-logging
+   ├── [namespace_name]       ## including openshift-logging
    │  ├── apps
    │  │  ├── daemonsets.yaml
    │  │  ├── deployments.yaml
@@ -94,6 +93,11 @@ Example must-gather for cluster-logging output:
    │  ├── batch
    │  │  ├── cronjobs.yaml
    │  │  └── jobs.yaml
+   │  ├── logging.openshift.io/
+   │  │  ├── clusterloggings
+   │  │  │  ├── instance.yaml
+   │  │  ├── clusterlogforwarders
+   │  │  │  └── [clf_name.yaml]
    │  ├── core
    │  │  ├── configmaps.yaml
    │  │  ├── endpoints.yaml
@@ -176,3 +180,8 @@ Example must-gather for cluster-logging output:
    └── openshift-operators-redhat
       ├── ...
 ```
+
+### Moved resources
+With the support of [multi log forwarder feature](https://docs.openshift.com/container-platform/4.14/logging/log_collection_forwarding/log-forwarding.html#log-forwarding-implementations-multi-clf_log-forwarding) in Openshift Cluster Logging 5.8, CLO resources are moved from `cluster-logging/clo/` to `cluster-logging/clo/[namespace_name]` (to allow multiple instances).
+
+Also, resources like `clusterlogging` and `clusterlogforwarder` are now collected into `namespaces/[namespace_name]/logging.openshift.io/` directories and not in `cluster-logging/clo`. That allows to use tools like [`omc`](https://github.com/gmeghnag/omc/) to work with those resources.

--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -185,3 +185,5 @@ Example must-gather for cluster-logging output:
 With the support of [multi log forwarder feature](https://docs.openshift.com/container-platform/4.14/logging/log_collection_forwarding/log-forwarding.html#log-forwarding-implementations-multi-clf_log-forwarding) in Openshift Cluster Logging 5.8, CLO resources are moved from `cluster-logging/clo/` to `cluster-logging/clo/[namespace_name]` (to allow multiple instances).
 
 Also, resources like `clusterlogging` and `clusterlogforwarder` are now collected into `namespaces/[namespace_name]/logging.openshift.io/` directories and not in `cluster-logging/clo`. That allows to use tools like [`omc`](https://github.com/gmeghnag/omc/) to work with those resources.
+
+The `deployments`, `daemonsets` and `secrets` can be also found in `namespaces/[namespace_name]/` and can be seen also with [`omc`](https://github.com/gmeghnag/omc/).

--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -184,6 +184,6 @@ Example must-gather for cluster-logging output:
 ### Moved resources
 With the support of [multi log forwarder feature](https://docs.openshift.com/container-platform/4.14/logging/log_collection_forwarding/log-forwarding.html#log-forwarding-implementations-multi-clf_log-forwarding) in Openshift Cluster Logging 5.8, CLO resources are moved from `cluster-logging/clo/` to `cluster-logging/clo/[namespace_name]` (to allow multiple instances).
 
-Also, resources like `clusterlogging` and `clusterlogforwarder` are now collected into `namespaces/[namespace_name]/logging.openshift.io/` directories and not in `cluster-logging/clo`. That allows to use tools like [`omc`](https://github.com/gmeghnag/omc/) to work with those resources.
+Also, resources like `clusterlogging` and `clusterlogforwarder` are now collected into `namespaces/[namespace_name]/logging.openshift.io/` directories and not in `cluster-logging/clo`. This allows to use tools like [`omc`](https://github.com/gmeghnag/omc/) to work with those resources in a similar way than a live cluster with `oc` commands.
 
 The `deployments`, `daemonsets` and `secrets` can be also found in `namespaces/[namespace_name]/` and can be seen also with [`omc`](https://github.com/gmeghnag/omc/).

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -49,6 +49,7 @@ cluster_resources+=(clusterrolebindings)
 cluster_resources+=(persistentvolumes)
 cluster_resources+=(clusterversion)
 cluster_resources+=(machineconfigpool)
+cluster_resources+=(customresourcedefinitions)
 
 log "-BEGIN inspecting CRs..." >> "${LOGFILE_PATH}"
 for cr in "${cluster_resources[@]}" ; do
@@ -65,6 +66,8 @@ resources+=(rolebindings)
 resources+=(configmaps)
 resources+=(serviceaccounts)
 resources+=(events)
+resources+=(clusterlogging)
+resources+=(clusterlogforwarder)
 
 log "BEGIN inspecting namespaces ..." >> "${LOGFILE_PATH}"
 
@@ -83,6 +86,8 @@ for namespace in "${cluster_resources[@]}" ; do
 done
 log "END inspecting namespaces ..." >> "${LOGFILE_PATH}"
 
+log "Data for 'clusterlogging' and 'clusterlogforwarder'" >> "${LOGFILE_PATH}"
+echo -e "See https://github.com/openshift/cluster-logging-operator/tree/master/must-gather#moved-resources" > $BASE_COLLECTION_PATH/cluster-logging/clo/clusterlogging_instance.txt
 
 log "BEGIN inspecting install resources ..." >> "${LOGFILE_PATH}"
 eo_found="$(oc -n openshift-operators-redhat get deployment elasticsearch-operator --ignore-not-found --no-headers)"
@@ -121,7 +126,7 @@ if [ "$found_es" != "" ] || [ "$found_lokistack" != "" ] ; then
   if [ "$found" != "" ] ; then
     KUBECACHEDIR=${BASE_COLLECTION_PATH}/cache-dir ${SCRIPT_DIR}/gather_visualization_resources "$BASE_COLLECTION_PATH" >> "${LOGFILE_PATH}" 2>&1
   fi
-  log "BEGIN gathering CLO resources ..." >> "${LOGFILE_PATH}"
+  log "END gathering logstorage resources ..." >> "${LOGFILE_PATH}"
 else
   log "Skipping logstorage inspection.  No Elasticsearch deployment found" >> "${LOGFILE_PATH}" 2>&1
 fi

--- a/must-gather/collection-scripts/gather_cluster_logging_operator_resources
+++ b/must-gather/collection-scripts/gather_cluster_logging_operator_resources
@@ -38,17 +38,6 @@ if [ $NAMESPACE == "openshift-logging" ]; then
   done
 fi
 
-log "Gathering data for 'clusterlogging' and 'clusterlogforwarder' from namespace: $NAMESPACE"
-for r in "clusterlogging" "clusterlogforwarder" ; do
-  names="$(oc -n $NAMESPACE get $r --ignore-not-found -o jsonpath='{.items[*].metadata.name}' | sort -u)"
-  for name in ${names[@]}; do
-    data="$(oc -n $NAMESPACE get $r ${name} --ignore-not-found -o yaml)"
-    if [ "$data" != "" ] ; then
-      echo $data > "${clo_folder}/${r}_${name}.yaml"
-    fi
-  done
-done
-
 log "Gathering 'secrets' from logging namespace: $NAMESPACE"
 oc -n $NAMESPACE get secrets -o yaml > ${clo_folder}/secrets.yaml 2>&1
 


### PR DESCRIPTION
### Description
Get the `clusterlogging` and `clusterlogforwarder` with the `oc adm inspect` command to allow working with those resources with [`omc`](https://github.com/gmeghnag/omc/) like in a "live" cluster.
The `customresourcedefinitions` are also required to allow `omc` to work with above (and other) resources (on testing, it adds only few MB to the full must-gather size for ~200 `customresourcedefinitions`).

Added a "Moved resources" section to the must-gather README to explain how to work with the `clusterlogging` and `clusterlogforwarder` after this change.