### PR TITLE
Adding missing resources in Logging 6 must-gather

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -57,13 +57,13 @@ cluster_resources+=(uiplugin)
 cluster_resources+=(customresourcedefinitions)
 
 log "- BEGIN inspecting cluster resources and namespaces..." | tee -a "${LOGFILE_PATH}"
-echo "${cluster_resources[@]}"
+
 for cr in "${cluster_resources[@]}" ; do
   log "-- BEGIN inspecting cluster resource ${cr} ..." | tee -a "${LOGFILE_PATH}"
   oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir="${BASE_COLLECTION_PATH}" "${cr}"  >> "${LOGFILE_PATH}" 2>&1 &
   pids+=($!)
 done
-echo "${namespace_resources[@]}"
+
 for ns in "${namespace_resources[@]}" ; do
   log "-- BEGIN inspecting namespace ${ns} ..." | tee -a "${LOGFILE_PATH}"
   oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir="${BASE_COLLECTION_PATH}" "ns/${ns}"  >> "${LOGFILE_PATH}" 2>&1 &
@@ -75,7 +75,7 @@ log "- END inspecting cluster resources..." | tee -a "${LOGFILE_PATH}"
 resources="pods,roles,rolebindings,configmaps,serviceaccounts,events,installplans,subscriptions,clusterserviceversions,logfilemetricexporter"
 
 log "BEGIN inspecting namespaced resources ..." | tee -a "${LOGFILE_PATH}"
-echo "${namespace_resources[@]}"
+
 for ns in ${namespace_resources[@]}    ; do
   # grab all our namespaces -- openshift-logging, openshift-operator-lifecycle-manager, openshift-operators-redhat
   # should also include any multi-forwarder namespaces found above

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -11,6 +11,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source ${SCRIPT_DIR}/common
 BASE_COLLECTION_PATH="${1:-/must-gather}"
 BASE_COLLECTION_PATH=$(cd "$(dirname -- $BASE_COLLECTION_PATH)" >/dev/null; pwd -P)/$(basename -- "$BASE_COLLECTION_PATH")
+
 LOGGING_NS="${2:-openshift-logging}"
 LOGFILE_NAME="${3:-gather-debug.log}"
 LOGFILE_PATH="${BASE_COLLECTION_PATH}/${LOGFILE_NAME}" # must-gather/gather-debug.log
@@ -22,25 +23,25 @@ log "must-gather logs are located at: '${LOGFILE_PATH}'"
 mkdir ${BASE_COLLECTION_PATH}/cache-dir||:
 export KUBECACHEDIR=${BASE_COLLECTION_PATH}/cache-dir
 
-# cluster-scoped resources
-cluster_resources=(ns/openshift-operator-lifecycle-manager)
+# namespaces
+namespace_resources=(openshift-operator-lifecycle-manager)
 
 # cluster logging operator namespace
-cluster_resources+=(ns/$LOGGING_NS)
+namespace_resources+=($LOGGING_NS)
 
 # elasticsearch operator namespace
-cluster_resources+=(ns/openshift-operators-redhat)
+namespace_resources+=(openshift-operators-redhat)
 
 # multi-forwarder namespaces
 for kind in $(oc get crd -A -o custom-columns=:.metadata.name | grep clusterlogforwarder); do
   namespaces=$(oc get $kind -A -o custom-columns=:.metadata.namespace | sort -u)
   for multi in ${namespaces} ; do
       # add to the list of namespaces
-      cluster_resources+=(ns/$multi)
-      log "Adding namespace '$multi' to cluster resources list" >> "${LOGFILE_PATH}"
+      namespace_resources+=($multi)
+      log "Adding namespace '$multi' to cluster resources list" | tee -a "${LOGFILE_PATH}"
 
       # get collector resources from the namespace
-      log "Inspecting collector resources in namespace '$multi'" | tee "${LOGFILE_PATH}"
+      log "Inspecting collector resources in namespace '$multi'" | tee -a "${LOGFILE_PATH}"
       ${SCRIPT_DIR}/gather_collection_resources "$BASE_COLLECTION_PATH" "$multi" 2>&1 >> "${LOGFILE_PATH}"
   done
 done
@@ -52,43 +53,47 @@ cluster_resources+=(clusterrolebindings)
 cluster_resources+=(persistentvolumes)
 cluster_resources+=(clusterversion)
 cluster_resources+=(machineconfigpool)
+cluster_resources+=(uiplugin)
 cluster_resources+=(customresourcedefinitions)
 
-log "- BEGIN inspecting cluster resources..." | tee "${LOGFILE_PATH}"
+log "- BEGIN inspecting cluster resources and namespaces..." | tee -a "${LOGFILE_PATH}"
+echo "${cluster_resources[@]}"
 for cr in "${cluster_resources[@]}" ; do
-  log "-- BEGIN inspecting cluster resource ${cr} ..." >> "${LOGFILE_PATH}"
+  log "-- BEGIN inspecting cluster resource ${cr} ..." | tee -a "${LOGFILE_PATH}"
   oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir="${BASE_COLLECTION_PATH}" "${cr}"  >> "${LOGFILE_PATH}" 2>&1 &
   pids+=($!)
 done
-log "- END inspecting cluster resources..." >> "${LOGFILE_PATH}"
+echo "${namespace_resources[@]}"
+for ns in "${namespace_resources[@]}" ; do
+  log "-- BEGIN inspecting namespace ${ns} ..." | tee -a "${LOGFILE_PATH}"
+  oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir="${BASE_COLLECTION_PATH}" "ns/${ns}"  >> "${LOGFILE_PATH}" 2>&1 &
+  pids+=($!)
+done
+log "- END inspecting cluster resources..." | tee -a "${LOGFILE_PATH}"
 
 # namespace-scoped resources
 resources="pods,roles,rolebindings,configmaps,serviceaccounts,events,installplans,subscriptions,clusterserviceversions,logfilemetricexporter"
 
-log "BEGIN inspecting namespaced resources ..." | tee "${LOGFILE_PATH}"
-
-for namespace in ${cluster_resources}    ; do
+log "BEGIN inspecting namespaced resources ..." | tee -a "${LOGFILE_PATH}"
+echo "${namespace_resources[@]}"
+for ns in ${namespace_resources[@]}    ; do
   # grab all our namespaces -- openshift-logging, openshift-operator-lifecycle-manager, openshift-operators-redhat
   # should also include any multi-forwarder namespaces found above
-  if [[ $namespace == ns/* ]]; then
-    ns=${namespace#ns/}  # remove "ns/" prefix
-      log "-- BEGIN inspecting ${ns}/${resources} ..." >> "${LOGFILE_PATH}"
-      oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir="${BASE_COLLECTION_PATH}" -n "$ns" "$resources" 2>&1 | tee "${LOGFILE_PATH}"  &
-      pids+=($!)
-  fi
+  log "-- BEGIN inspecting ${ns}/${resources} ..." | tee -a "${LOGFILE_PATH}"
+  oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir="${BASE_COLLECTION_PATH}" -n "$ns" "$resources" 2>&1 | tee -a "${LOGFILE_PATH}"  &
+  pids+=($!)
 
 done
-log "END inspecting namespaced resources ..." >> "${LOGFILE_PATH}"
-
+log "END inspecting namespaced resources ..." | tee -a "${LOGFILE_PATH}"
 
 default_clo_found="$(oc -n "$LOGGING_NS" get deployment cluster-logging-operator --ignore-not-found --no-headers)"
 
 if [ "$default_clo_found" != "" ] ; then
-  log "BEGIN gathering default CLO resources ..." | tee "${LOGFILE_PATH}"
+  log "BEGIN gathering default CLO resources ..." | tee -a "${LOGFILE_PATH}"
   ${SCRIPT_DIR}/gather_cluster_logging_operator_resources "$BASE_COLLECTION_PATH" "$LOGGING_NS" 2>&1 >> "${LOGFILE_PATH}"
-  log "END gathering default CLO resources ..." >> "${LOGFILE_PATH}"
+  log "END gathering default CLO resources ..." | tee -a "${LOGFILE_PATH}"
 else
-  log "Skipping collection inspection.  No default CLO found" 2>&1 | tee "${LOGFILE_PATH}"
+  log "Skipping collection inspection.  No default CLO found" 2>&1 | tee -a "${LOGFILE_PATH}"
 fi
 
 loki_crd=$(oc get crd -A -o custom-columns=:.metadata.name | grep lokistack)
@@ -97,11 +102,11 @@ if [ "$loki_crd" != "" ] ; then
   found_lokistack="$(oc -n $LOGGING_NS get lokistack.loki.grafana.com --ignore-not-found --no-headers)"
   if [ "$found_lokistack" != "" ] ; then
 
-    log "BEGIN gathering lokistack resources ..." | tee "${LOGFILE_PATH}"
-    ${SCRIPT_DIR}/gather_logstore_resources "$BASE_COLLECTION_PATH" "lokistack" 2>&1 | tee "${LOGFILE_PATH}"
-    log "END gathering logstorage resources ..."  >> "${LOGFILE_PATH}"
+    log "BEGIN gathering lokistack resources ..." | tee -a "${LOGFILE_PATH}"
+    ${SCRIPT_DIR}/gather_logstore_resources "$BASE_COLLECTION_PATH" "lokistack" 2>&1 >>  "${LOGFILE_PATH}"
+    log "END gathering logstorage resources ..."  | tee -a "${LOGFILE_PATH}"
   else
-    log "Skipping logstorage inspection.  No deployment found" 2>&1 | tee "${LOGFILE_PATH}"
+    log "Skipping logstorage inspection.  No deployment found" 2>&1 | tee -a "${LOGFILE_PATH}"
   fi
 fi
 

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -37,8 +37,10 @@ for kind in $(oc get crd -A -o custom-columns=:.metadata.name | grep clusterlogf
   namespaces=$(oc get $kind -A -o custom-columns=:.metadata.namespace | sort -u)
   for multi in ${namespaces} ; do
       # add to the list of namespaces
-      namespace_resources+=($multi)
-      log "Adding namespace '$multi' to cluster resources list" | tee -a "${LOGFILE_PATH}"
+      if [ "$multi" != "$LOGGING_NS" ] ; then
+        namespace_resources+=($multi)
+        log "Adding namespace '$multi' to cluster resources list" | tee -a "${LOGFILE_PATH}"
+      fi
 
       # get collector resources from the namespace
       log "Inspecting collector resources in namespace '$multi'" | tee -a "${LOGFILE_PATH}"
@@ -85,6 +87,15 @@ for ns in ${namespace_resources[@]}    ; do
 
 done
 log "END inspecting namespaced resources ..." | tee -a "${LOGFILE_PATH}"
+
+# if the uiplugin is installed, collect the console CO
+uiplugin_found="$(oc get uiplugin --ignore-not-found --no-headers)"
+if [ "$uiplugin_found" != "" ] ; then
+  log "BEGIN gathering console resources ..." | tee -a "${LOGFILE_PATH}"
+  oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir="${BASE_COLLECTION_PATH}" co/console 2>&1 | tee -a "${LOGFILE_PATH}"  &
+  pids+=($!)
+  log "END gathering console resources ..." | tee -a "${LOGFILE_PATH}"
+fi
 
 default_clo_found="$(oc -n "$LOGGING_NS" get deployment cluster-logging-operator --ignore-not-found --no-headers)"
 

--- a/must-gather/collection-scripts/gather_collection_resources
+++ b/must-gather/collection-scripts/gather_collection_resources
@@ -28,7 +28,7 @@ crs="$(oc get clusterLogForwarder.observability.openshift.io -n $NAMESPACE -o cu
 for collector in ${crs}; do
   log "-- Gathering data for ClusterLogForwarder: $collector"
   mkdir -p $collector_folder
-  oc -n $NAMESPACE get clusterLogForwarder.observability.openshift.io/$collector -o yaml > $collector_folder/$collector.yaml --cache-dir=${KUBECACHEDIR} 2>&1
+  oc adm inspect -n $NAMESPACE clusterLogForwarders.observability.openshift.io --cache-dir=${KUBECACHEDIR} 2>&1
 
   # find daemonset
   log "--- Describe Daemonset ds/$collector"

--- a/must-gather/collection-scripts/gather_logstore_resources
+++ b/must-gather/collection-scripts/gather_logstore_resources
@@ -18,15 +18,13 @@ NAMESPACE=${3:-openshift-logging}
 CLO_COLLECTION_PATH="$BASE_COLLECTION_PATH/cluster-logging"
 es_folder="$CLO_COLLECTION_PATH/es"
 
-lokistack_folder="$CLO_COLLECTION_PATH/lokistack"
-
 list_es_storage() {
   local pod=$1
   local mountPath=$(oc -n $NAMESPACE get pod $pod -o jsonpath='{.spec.containers[0].volumeMounts[?(@.name=="elasticsearch-storage")].mountPath}')
   echo "-- Persistence files" >> $es_folder/$pod
 
   oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR}  exec -c elasticsearch $pod -- ls -lR $mountPath >> $es_folder/$pod
-  
+
   echo "-- Persistence  storage size " >> $es_folder/$pod-storage
 
   oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR}  exec -c elasticsearch $pod -- df -h $mountPath >> $es_folder/$pod-storage
@@ -77,11 +75,11 @@ get_elasticsearch_status() {
 }
 
 get_elasticsearch_cr() {
-  oc get -n $NAMESPACE --cache-dir=${KUBECACHEDIR} elasticsearch.logging.openshift.io elasticsearch -o yaml > $es_folder/elasticsearch_cr.yaml
+  oc adm inspect -n $NAMESPACE --cache-dir=${KUBECACHEDIR} elasticsearch.logging.openshift.io elasticsearch
 }
 
 get_lokistack_cr() {
-  oc get -n $NAMESPACE --cache-dir=${KUBECACHEDIR} lokistacks.loki.grafana.com -o yaml > $lokistack_folder/lokistack_cr.yaml
+  oc adm inspect -n $NAMESPACE --cache-dir=${KUBECACHEDIR} lokistacks.loki.grafana.com
 }
 
 log "Gathering data for logstore component"
@@ -111,7 +109,6 @@ fi
 
 if [ "$LOG_STORE_TYPE" = "lokistack" ] ; then
   log "Gathering Lokistack resources"
-  mkdir -p "$lokistack_folder"
 
   log "-- Gather Lokistack CR"
   get_lokistack_cr


### PR DESCRIPTION
Added some missing resources, and collect them with `oc adm inspect` for being compatible with `omc` tool.
Separated `namespaces` and `cluster_resources` for clarity and because different data is collected from them. Not adding `$multi` to `namespace_resources` when it's already `$LOGGING_NS`.
Collecting `console` Cluster Operator if the UIPlugin is present.